### PR TITLE
Upgrade to Zonemaster release 2022.2

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,7 +14,7 @@ jobs:
 
     runs-on: ubuntu-latest
     env:
-      ZMREL: 2022.1.1
+      ZMREL: 2022.2-1
 
     steps:
       - name: Check out repository

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -37,14 +37,14 @@ jobs:
           echo "RELEASE=$ZMREL" >> "$GITHUB_ENV"
 
       - name: Login to GHCR
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           pull: true
           push: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,13 +14,13 @@ RUN apt-get update \
   libintl-perl \
   libio-socket-inet6-perl \
   libjson-xs-perl \
-  libldns-dev \
   liblist-moreutils-perl \
   libmailtools-perl \
   libmodule-find-perl \
   libmodule-install-xsutil-perl \
   libmoosex-getopt-perl \
   libmoosex-singleton-perl \
+  libnet-ip-xs-perl \
   libpod-coverage-perl \
   libreadonly-perl \
   libssl-dev \
@@ -31,12 +31,12 @@ RUN apt-get update \
   libtest-pod-perl \
   libtext-csv-perl \
   libtext-reflow-perl \
+  libtry-tiny-perl \
   make \
   && rm -rf /var/lib/apt/lists/*
-RUN cpanm --configure-args="--no-internal-ldns" \
-             https://cpan.metacpan.org/authors/id/Z/ZN/ZNMSTR/Zonemaster-LDNS-2.2.2.tar.gz \
-    && cpanm https://cpan.metacpan.org/authors/id/Z/ZN/ZNMSTR/Zonemaster-Engine-v4.5.1.tar.gz \
-    && cpanm https://cpan.metacpan.org/authors/id/Z/ZN/ZNMSTR/Zonemaster-CLI-v4.0.1.tar.gz \
+RUN cpanm https://cpan.metacpan.org/authors/id/Z/ZN/ZNMSTR/Zonemaster-LDNS-3.0.0.tar.gz \
+    && cpanm https://cpan.metacpan.org/authors/id/Z/ZN/ZNMSTR/Zonemaster-Engine-v4.6.0.tar.gz \
+    && cpanm https://cpan.metacpan.org/authors/id/Z/ZN/ZNMSTR/Zonemaster-CLI-v5.0.0.tar.gz \
     && rm -rf /root/.cpanm/
 COPY entry /entry
 COPY profile.json.in /etc/zonemaster-profile.json.in

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:22.10
 LABEL org.opencontainers.image.source="https://github.com/andreaso/zonemaster-image"
 RUN apt-get update \
   && apt-get install --yes --no-install-recommends \

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ for the Zonemaster project.
 ## Usage
 
 ```shell
-docker run --rm --user=4848 --cap-drop=all --security-opt=no-new-privileges --read-only --tty ghcr.io/andreaso/zonemaster-cli:2022.1.1 --help
+docker run --rm --user=4848 --cap-drop=all --security-opt=no-new-privileges --read-only --tty ghcr.io/andreaso/zonemaster-cli:2022.2-1 --help
 ```
 
 ```shell
-docker run --rm --user=4848 --cap-drop=all --security-opt=no-new-privileges --read-only --network=host --tty ghcr.io/andreaso/zonemaster-cli:2022.1.1 DOMAIN
+docker run --rm --user=4848 --cap-drop=all --security-opt=no-new-privileges --read-only --network=host --tty ghcr.io/andreaso/zonemaster-cli:2022.2-1 DOMAIN
 ```
 
 (Suggesting `--network=host` since it's more likely to have IPv6 connectivity by default.)

--- a/profile.json.in
+++ b/profile.json.in
@@ -7,7 +7,6 @@
     "address02",
     "address03",
     "basic03",
-    "basic04",
     "connectivity01",
     "connectivity02",
     "connectivity03",


### PR DESCRIPTION
* Introducing packaging version suffix (-1)
* Returning to internal LDNS. bbb2834 is no longer an issue.

Upstream release: https://github.com/zonemaster/zonemaster/releases/tag/v2022.2